### PR TITLE
Updated readme with note about project deprecation and location of ar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 ## Overview
 
+NOTE: this project is deprecated and archived at <a href="https://github.com/bambora-na/na-ios-checkout">https://github.com/bambora-na/na-ios-checkout</a>. Feel free to delete this project.
+
 Checkout is a client-side iOS framework that handles customer credit card input within a merchant's mobile app. This iOS framework limits the scope of a merchant's PCI compliance by removing the need for them to pass the sensitive information (credit card number, CVD, or expiry) through their servers and from having to write and store code that comes in contact with that sensitive information.
 
 By integrating Checkout a developer can easily provide a way for users to accept payments in an iOS app. Checkout provides some client-side validation, smart field data formatting and a design that works in all iOS device form factors.


### PR DESCRIPTION
I don't have permission to delete this project from the Bambora repo so I'm adding a note to the readme about where the official archive is. Once this change is in for this project and the android checkout project I'll make another change in the https://github.com/bambora/git-repositories project to archive the ios and android checkout projects.